### PR TITLE
Optimising Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN <<EOF
         else export DOCKERIZE_ARCH=amd64;
     fi
     
-    wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-$DOCKERIZE_ARCH-$DOCKERIZE_VERSION.tar.gz -O - | tar -xzv -C /usr/local/bin
+    wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-$DOCKERIZE_ARCH-$DOCKERIZE_VERSION.tar.gz -O - | tar -xzv -C /usr/local/bin
     
     chown root:root /usr/local/bin/dockerize
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,15 @@ COPY frontend/webpack* frontend/tsconfig.json ./
 COPY frontend/assets assets
 COPY frontend/src src
 COPY frontend/theme theme
-RUN yarn run build
-RUN yarn run build:server
+RUN yarn run build && yarn run build:server
 
 FROM node:12-alpine AS frontend
 WORKDIR /app
 COPY --from=frontend-build /app/build build
 COPY --from=frontend-build /app/build-server build-server
 COPY frontend/package.json .
+
+VOLUME /app-dist
 
 CMD ["npm", "start"]
 
@@ -23,14 +24,23 @@ CMD ["npm", "start"]
 FROM python:3.7-alpine AS build-backend
 ARG EXTRA_DEPS
 
-RUN apk add build-base musl-dev libffi-dev openssl-dev mariadb-dev
-
 WORKDIR /app
-RUN pip install -U setuptools 'cryptography>=3.0,<3.1' poetry==1.1.7
+
+COPY backend/requirements.txt ./
+
+RUN <<EOF
+    set -x
+    apk --no-cache add build-base musl-dev libffi-dev openssl-dev mariadb-dev
+    pip install -U setuptools -r requirements.txt
+EOF
+
 COPY backend/pyproject.toml backend/poetry.lock ./
-RUN poetry config virtualenvs.path /venv
-RUN poetry install --no-dev --no-ansi --no-interaction
-RUN poetry run pip install -U setuptools $EXTRA_DEPS
+RUN <<EOF
+    set -x
+    poetry config virtualenvs.path /venv
+    poetry install --no-dev --no-ansi --no-interaction
+    poetry run pip install -U setuptools $EXTRA_DEPS
+EOF
 
 COPY backend/manage.py backend/gunicorn.conf.py ./
 COPY backend/tabby tabby
@@ -38,27 +48,34 @@ COPY --from=frontend /app/build /frontend
 
 ARG BUNDLED_TABBY=1.0.163
 
-RUN FRONTEND_BUILD_DIR=/frontend /venv/*/bin/python ./manage.py collectstatic --noinput
-RUN FRONTEND_BUILD_DIR=/frontend /venv/*/bin/python ./manage.py add_version ${BUNDLED_TABBY}
+RUN <<EOF
+    set -x
+    FRONTEND_BUILD_DIR=/frontend /venv/*/bin/python ./manage.py collectstatic --noinput
+    FRONTEND_BUILD_DIR=/frontend /venv/*/bin/python ./manage.py add_version ${BUNDLED_TABBY}
+EOF
 
 FROM python:3.7-alpine AS backend
 
-ENV DOCKERIZE_VERSION v0.6.1
-ENV DOCKERIZE_ARCH amd64
+ENV DOCKERIZE_VERSION=v0.6.1
+ENV DOCKERIZE_ARCH=amd64
 ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; \
-    then export DOCKERIZE_ARCH=armhf; \
-    else export DOCKERIZE_ARCH=amd64; \
+RUN <<EOF
+    set -ex
+    if [ "$TARGETPLATFORM" = "linux/arm64" ];
+        then export DOCKERIZE_ARCH=armhf;
+        else export DOCKERIZE_ARCH=amd64;
     fi
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-$DOCKERIZE_ARCH-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-$DOCKERIZE_ARCH-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-linux-$DOCKERIZE_ARCH-$DOCKERIZE_VERSION.tar.gz
+    
+    wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-$DOCKERIZE_ARCH-$DOCKERIZE_VERSION.tar.gz -O - | tar -xzv -C /usr/local/bin
+    
+    chown root:root /usr/local/bin/dockerize
 
-RUN apk add mariadb-connector-c
+    apk add --no-cache mariadb-connector-c
+EOF
 
 COPY --from=build-backend /app /app
 COPY --from=build-backend /venv /venv
 
-COPY backend/start.sh backend/manage.sh /
-RUN chmod +x /start.sh /manage.sh
+COPY --chmod=755 backend/start.sh backend/manage.sh /
+
 CMD ["/start.sh"]

--- a/backend/manage.sh
+++ b/backend/manage.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-/wait
+/wait # Error starting command: `"-wait` - exec: "\"-wait": executable file not found in $PATH
 cd /app
 /venv/*/bin/python ./manage.py $@

--- a/backend/manage.sh
+++ b/backend/manage.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-/wait # Error starting command: `"-wait` - exec: "\"-wait": executable file not found in $PATH
+/wait
 cd /app
 /venv/*/bin/python ./manage.py $@

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+cryptography>=3.0,<3.1 
+poetry==1.1.7


### PR DESCRIPTION
Heya, great project! Looking forward to using it, hope you don't mind the PR!

## Changes

- Optimised Dockerfile for BUILDKIT (approx 35% buildtime improvement)
- Fixed Dockerize (was using Ubuntu version, not Alpine) + raised an issue (https://github.com/jwilder/dockerize/issues/180) about UID:GID.
- Changed how Dockerize was downloaded to reduce the amount of steps/layers.
- Added VOLUME for frontend so if a user inputs something wrong in the compose file, it'll still create a volume and function.
- Added requirements.txt as this allows for easier updating via automated github tools such as dependabot/renovate.

---

## Things to note:
- There is an issue here where the output is `"Error starting command: "-wait - exec: "\"-wait": executable file not found in $PATH"` (on current version and also tested on ghcr.io/eugeny/tabby-web:latest just in case it was my build)
https://github.com/Eugeny/tabby-web/blob/156341173a42de346b1785602961da40d77a3c66/backend/manage.sh#L2
- Cryptography package seems quite out of date? Current version is 37.0.4. It also seems to be built twice, once in pip + once in poetry? As a note, for multiarch builds, cryptography takes to build *ages* on ARM under QEMU.
  - Potentially consider a Pypi index (such as https://wheel-index.linuxserver.io/alpine-3.16/ or https://github.com/modem7/PyPI) to reduce pip package build times if you go down the multi-arch route in ghcr.
    - As an addendum, using the index method, I managed to reduce the Borgmatic project build times from ~1 hour to ~6 minutes. 
- Image is optimised for buildkit/buildx. This may cause a problem with users building their dockerfiles unless they do `DOCKER_BUILDKIT=1`

---

Happy to discuss any changes/concerns!