### PR TITLE
Update deprecated X-Frame-Options to CSP frame-ancestors for demo embed

### DIFF
--- a/backend/tabby/app/views.py
+++ b/backend/tabby/app/views.py
@@ -25,7 +25,7 @@ class TerminalView(APIView):
 class DemoView(APIView):
     def get(self, request, format=None):
         response = static.serve(request, 'demo.html', document_root=str(settings.STATIC_ROOT))
-        response['X-Frame-Options'] = 'ALLOW-FROM https://tabby.sh'
+        response['Content-Security-Policy'] = 'frame-ancestors https://tabby.sh'
         return response
 
 


### PR DESCRIPTION
See #74

Docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors

**Warning:** Have not tested as I would need to set up the domains and subdomains and was too lazy for that