### PR TITLE
Fix tar: invalid magic error when running add_version

### DIFF
--- a/backend/tabby/app/management/commands/add_version.py
+++ b/backend/tabby/app/management/commands/add_version.py
@@ -49,6 +49,7 @@ class Command(BaseCommand):
 
                 with tempfile.NamedTemporaryFile("wb") as f:
                     f.write(response.content)
+                    f.flush()
                     plugin_final_target = Path(tempdir) / plugin
 
                     with tempfile.TemporaryDirectory() as extraction_tmp:


### PR DESCRIPTION
fix https://github.com/Eugeny/tabby-web/issues/86#issuecomment-1872535594

### Problem Description
When downloading and saving a file, running the tar command to extract it occasionally fails with the following errors:
```
tar: invalid magic  
tar: short read  
This issue occurs even with small files (e.g., 66 KB).
```
### Cause Analysis
Python’s file I/O uses a buffered mechanism, meaning `f.write()` may temporarily store data in memory without immediately writing it to the filesystem.
If `tar` attempts to extract the file before the data is fully written, it may read an incomplete or corrupted file, causing the extraction to fail.
The issue is more likely to occur in high-load environments or with delayed disk I/O.
Solution
Add `f.flush()` immediately after `f.write()` to ensure the file buffer is flushed to the operating system before invoking the tar command. This guarantees the file is fully written and ready for further operations.