### PR TITLE
Fix incorrect copying of `tempdir` to `app-dist` during `add_version`…

### DIFF
--- a/backend/tabby/app/management/commands/add_version.py
+++ b/backend/tabby/app/management/commands/add_version.py
@@ -62,4 +62,9 @@ class Command(BaseCommand):
             if fs.exists(target):
                 fs.rm(target, recursive=True)
             fs.mkdir(target)
-            fs.put(str(tempdir), target, recursive=True)
+            # Copy each item from the temporary directory to the target
+            for item in tempdir.iterdir():
+                if item.is_dir():
+                    fs.put(str(item), target, recursive=True)
+                else:
+                    fs.put(str(item), target)


### PR DESCRIPTION
### Problem Description
When copying files from the temporary directory to the target location using `fs.put(str(tempdir), target, recursive=True)`, the temporary directory itself (e.g., `/tmp/tmp7w4ldc08`) is included in the target path. As a result, files are copied into `{target}/tmp7w4ldc08` instead of directly into `{target}`.

### Cause Analysis
The `fs.put()` function copies the specified source path (in this case, `tempdir`) and its entire structure to the destination. This behavior includes the temporary directory's name in the copied path, resulting in an undesired directory structure.