### PR TITLE
docs: add system requirements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,41 @@ Tabby Web serves the [Tabby Terminal](https://github.com/Eugeny/tabby) as a web 
 
 # Requirements
 
-* Python 3.7+
+## Software Requirements
+
+* Python 3.10+ (3.12 recommended)
+* Node.js 18+ (for frontend build)
 * A database server supported by Django (MariaDB, Postgres, SQLite, etc.)
 * Storage for distribution files - local, S3, GCS or others supported by `fsspec`
+* Docker and Docker Compose (for containerized deployment)
+
+## System Requirements
+
+### Minimum (Build & Run)
+
+| Resource | Requirement |
+|----------|-------------|
+| CPU | 2 cores |
+| RAM | 2GB (4GB recommended for building) |
+| Disk | 5GB |
+
+> **Note:** Building the Docker image requires significant memory for the frontend compilation step. If you're running on a memory-constrained system (like Oracle Cloud Free Tier), consider using a pre-built image or building on a machine with more RAM.
+
+### Runtime Only (Pre-built Image)
+
+| Resource | Requirement |
+|----------|-------------|
+| CPU | 1 core |
+| RAM | 512MB |
+| Disk | 1GB + app distributions |
+
+### Recommended (Production)
+
+| Resource | Requirement |
+|----------|-------------|
+| CPU | 2+ cores |
+| RAM | 2GB |
+| Disk | 10GB |
 
 # Quickstart (using `docker-compose`)
 


### PR DESCRIPTION
## Summary

Add detailed system requirements to the README to help users understand what resources they need before attempting to deploy tabby-web.

## Changes

Added three requirement tiers:

### Minimum (Build & Run)
- 2 cores, 2GB RAM (4GB recommended for building), 5GB disk
- Note about memory-constrained systems like Oracle Cloud Free Tier

### Runtime Only (Pre-built Image)
- 1 core, 512MB RAM, 1GB disk + app distributions
- For users running pre-built Docker images

### Recommended (Production)
- 2+ cores, 2GB RAM, 10GB disk

## Context

Issue #132 reported that building tabby-web failed on Oracle Cloud Free Tier due to insufficient memory during the frontend compilation step. This documentation helps users:
1. Know what resources they need upfront
2. Understand the difference between build and runtime requirements
3. Consider using pre-built images on constrained systems

Fixes #132