### PR TITLE
feat: add Azure AD single-tenant authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,20 @@ For SSH and Telnet, once logged in, enter your connection gateway address and au
 
 * `DATABASE_URL` (required).
 * `APP_DIST_STORAGE`: a `file://`, `s3://`, or `gcs://` URL to store app distros in.
-* `SOCIAL_AUTH_*_KEY` & `SOCIAL_AUTH_*_SECRET`: social login credentials, supported providers are `GITHUB`, `GITLAB`, `MICROSOFT_GRAPH` and `GOOGLE_OAUTH2`.
+
+### OAuth Providers
+
+Configure one or more OAuth providers for authentication:
+
+| Provider | Variables |
+|----------|-----------|
+| GitHub | `SOCIAL_AUTH_GITHUB_KEY`, `SOCIAL_AUTH_GITHUB_SECRET` |
+| GitLab | `SOCIAL_AUTH_GITLAB_KEY`, `SOCIAL_AUTH_GITLAB_SECRET` |
+| Google | `SOCIAL_AUTH_GOOGLE_OAUTH2_KEY`, `SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET` |
+| Microsoft (multi-tenant) | `SOCIAL_AUTH_MICROSOFT_GRAPH_KEY`, `SOCIAL_AUTH_MICROSOFT_GRAPH_SECRET` |
+| Azure AD (single-tenant) | `SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_KEY`, `SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_SECRET`, `SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_TENANT_ID` |
+
+**Azure AD Single-Tenant:** Use this instead of Microsoft Graph if you want to restrict login to users from a specific Azure AD tenant (organization). Set `TENANT_ID` to your Azure AD Directory (tenant) ID.
 
 ## Adding Tabby app versions
 

--- a/backend/tabby/settings.py
+++ b/backend/tabby/settings.py
@@ -138,6 +138,7 @@ AUTHENTICATION_BACKENDS = (
     "social_core.backends.github.GithubOAuth2",
     "social_core.backends.gitlab.GitLabOAuth2",
     "social_core.backends.azuread.AzureADOAuth2",
+    "social_core.backends.azuread_tenant.AzureADTenantOAuth2",  # Single-tenant Azure AD
     "social_core.backends.microsoft.MicrosoftOAuth2",
     "social_core.backends.google.GoogleOAuth2",
     "django.contrib.auth.backends.ModelBackend",
@@ -180,6 +181,10 @@ for key in [
     "SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET",
     "SOCIAL_AUTH_MICROSOFT_GRAPH_KEY",
     "SOCIAL_AUTH_MICROSOFT_GRAPH_SECRET",
+    # Azure AD single-tenant (use instead of multi-tenant for org-only access)
+    "SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_KEY",
+    "SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_SECRET",
+    "SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_TENANT_ID",
     "CONNECTION_GATEWAY_AUTH_CA",
     "CONNECTION_GATEWAY_AUTH_CERTIFICATE",
     "CONNECTION_GATEWAY_AUTH_KEY",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,24 @@ services:
         - PORT=80
         - DEBUG=False
         - DOCKERIZE_ARGS="-wait tcp://db:3306 -timeout 60s"
+        #
+        # OAuth Providers - uncomment and configure:
+        # - SOCIAL_AUTH_GITHUB_KEY=your_github_client_id
+        # - SOCIAL_AUTH_GITHUB_SECRET=your_github_client_secret
+        # - SOCIAL_AUTH_GITLAB_KEY=your_gitlab_client_id
+        # - SOCIAL_AUTH_GITLAB_SECRET=your_gitlab_client_secret
+        # - SOCIAL_AUTH_GOOGLE_OAUTH2_KEY=your_google_client_id
+        # - SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET=your_google_client_secret
+        #
+        # Microsoft/Azure AD (multi-tenant - allows any Microsoft account):
+        # - SOCIAL_AUTH_MICROSOFT_GRAPH_KEY=your_microsoft_client_id
+        # - SOCIAL_AUTH_MICROSOFT_GRAPH_SECRET=your_microsoft_client_secret
+        #
+        # Azure AD Single-Tenant (restricts to specific organization):
+        # - SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_KEY=your_azure_client_id
+        # - SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_SECRET=your_azure_client_secret
+        # - SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_TENANT_ID=your_tenant_id
+        #
         # - APP_DIST_STORAGE="file:///app-dist"
 
     db:


### PR DESCRIPTION
## Summary

Add support for `AzureADTenantOAuth2` backend which allows restricting authentication to a specific Azure AD tenant (organization).

## Problem

Issue #120 reported that the existing Microsoft Graph OAuth doesn't support single-tenant authentication - it allows any Microsoft account to log in, including personal accounts and users from other organizations.

## Solution

Added the `social_core.backends.azuread_tenant.AzureADTenantOAuth2` backend which requires a tenant ID, restricting authentication to only users from that specific Azure AD directory.

## Configuration

```yaml
environment:
  - SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_KEY=your_azure_client_id
  - SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_SECRET=your_azure_client_secret
  - SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_TENANT_ID=your_tenant_id
```

The tenant ID is your Azure AD Directory (tenant) ID, found in the Azure Portal under Azure Active Directory > Properties.

## Changes

- Added `AzureADTenantOAuth2` to authentication backends
- Added environment variable support for the three required settings
- Updated `docker-compose.yml` with configuration examples
- Updated `README.md` with OAuth provider documentation table

## Callback URL

When configuring your Azure AD app, use this redirect URL:
```
https://YOUR_DOMAIN/complete/azuread-tenant-oauth2/
```

Fixes #120

Sources:
- [Python Social Auth Azure AD Documentation](https://python-social-auth.readthedocs.io/en/latest/backends/azuread.html)
- [AzureADTenantOAuth2 Backend Source](https://github.com/python-social-auth/social-core/blob/master/social_core/backends/azuread_tenant.py)