### PR TITLE
docs: document pre-built Docker image from GHCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,29 @@ You'll need:
 
 * OAuth credentials from GitHub, GitLab, Google or Microsoft for authentication.
 * For SSH and Telnet: a [`tabby-connection-gateway`](https://github.com/Eugeny/tabby-connection-gateway) to forward traffic.
-* Docker BuildKit: `export DOCKER_BUILDKIT=1`
+
+## Option 1: Pre-built Image (Recommended)
+
+Use the pre-built image from GitHub Container Registry - no build required:
 
 ```bash
-    docker-compose up -e SOCIAL_AUTH_GITHUB_KEY=xxx -e SOCIAL_AUTH_GITHUB_SECRET=yyy
+docker-compose -f docker-compose.prebuilt.yml up -d
 ```
 
-will start Tabby Web on port 9090 with MariaDB as a storage backend.
+The image is available at `ghcr.io/eugeny/tabby-web:latest`.
+
+## Option 2: Build from Source
+
+If you need to customize the build:
+
+```bash
+export DOCKER_BUILDKIT=1
+docker-compose up -d
+```
+
+---
+
+Both options will start Tabby Web on port 9090 with MariaDB as a storage backend.
 
 For SSH and Telnet, once logged in, enter your connection gateway address and auth token in the settings.
 

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -1,0 +1,40 @@
+# Use this file for quick deployment with pre-built images (no build required)
+# Usage: docker-compose -f docker-compose.prebuilt.yml up -d
+
+services:
+    tabby:
+        image: ghcr.io/eugeny/tabby-web:latest
+        restart: always
+        depends_on:
+        - db
+        ports:
+        - 9090:80
+        environment:
+        - DATABASE_URL=mysql://root:123@db/tabby
+        - PORT=80
+        - DEBUG=False
+        - DOCKERIZE_ARGS="-wait tcp://db:3306 -timeout 60s"
+        #
+        # OAuth Providers - uncomment and configure at least one:
+        # - SOCIAL_AUTH_GITHUB_KEY=your_github_client_id
+        # - SOCIAL_AUTH_GITHUB_SECRET=your_github_client_secret
+        # - SOCIAL_AUTH_GITLAB_KEY=your_gitlab_client_id
+        # - SOCIAL_AUTH_GITLAB_SECRET=your_gitlab_client_secret
+        # - SOCIAL_AUTH_GOOGLE_OAUTH2_KEY=your_google_client_id
+        # - SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET=your_google_client_secret
+        # - SOCIAL_AUTH_MICROSOFT_GRAPH_KEY=your_microsoft_client_id
+        # - SOCIAL_AUTH_MICROSOFT_GRAPH_SECRET=your_microsoft_client_secret
+
+    db:
+        image: mariadb:10.7.1
+        restart: always
+        environment:
+            MARIADB_DATABASE: tabby
+            MARIADB_USER: user
+            MARIADB_PASSWORD: 123
+            MYSQL_ROOT_PASSWORD: 123
+        volumes:
+        - db-data:/var/lib/mysql
+
+volumes:
+    db-data:


### PR DESCRIPTION
## Summary

Document the existing pre-built Docker images on GHCR and add a convenience `docker-compose.prebuilt.yml` file.

## Problem

Issue #115 asked about pre-built container images. The images actually exist at `ghcr.io/eugeny/tabby-web:latest` (built by the existing GitHub Actions workflow), but they weren't documented anywhere.

Users attempting to deploy on memory-constrained systems (like Oracle Cloud Free Tier) couldn't easily discover they could skip the build step entirely.

## Solution

1. Added `docker-compose.prebuilt.yml` that uses the GHCR image directly
2. Updated README to prominently feature pre-built images as the recommended option
3. Clearly documented the image location: `ghcr.io/eugeny/tabby-web:latest`

## Usage

```bash
# Quick start with pre-built image (no build required!)
docker-compose -f docker-compose.prebuilt.yml up -d
```

## Benefits

- **No build required** - Just pull and run
- **Works on low-memory systems** - No 4GB+ RAM needed for frontend build
- **Faster deployment** - Skip the build step entirely
- **Multi-arch support** - Images available for linux/amd64 and linux/arm64

Fixes #115