### PR TITLE
Fix in-browser SSH public-key authentication (wrong private key type)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,32 @@ When registering your app in Azure portal, select "Accounts in this organization
 
 You can find the available version numbers [here](https://www.npmjs.com/package/tabby-web-container).
 
+# SSH public-key authentication fix (web build)
+
+Upstream Tabby Web (and the hosted `app.tabby.sh`) cannot authenticate SSH
+sessions with a private key from the browser — the connection fails with
+`Error signing data with key: wrong private key type`, so only password auth
+works. See [Eugeny/tabby#8069](https://github.com/Eugeny/tabby/issues/8069) and
+[Eugeny/tabby-connection-gateway#11](https://github.com/Eugeny/tabby-connection-gateway/issues/11).
+
+**Root cause:** Tabby runs `ssh2` in the browser, where Node's `crypto` is
+polyfilled by `browserify-sign`. When signing the public-key challenge for an
+RSA key, `ssh2` requests the bare digest name (`sha256` / `sha512`), but
+`browserify-sign` maps those names to an **ECDSA** algorithm entry whose PKCS#1
+`DigestInfo` prefix is empty. The RSA signing path therefore either throws
+`wrong private key type` or emits a signature with no `DigestInfo`, which the
+server rejects. The desktop app is unaffected because it uses native `crypto`.
+
+**Fix:** this fork rewrites the requested algorithm to the proper
+`RSA-SHA512` / `RSA-SHA256` names (which carry the correct `DigestInfo`) when an
+app version is downloaded, so it produces valid `rsa-sha2-*` signatures. The
+rewrite lives in `add_version` (`backend/tabby/app/management/commands/add_version.py`)
+and is applied automatically to every downloaded version — no manual step needed.
+
+> Note: this is a post-build patch of the published bundles. The underlying bug
+> lives in the `ssh2` / `browserify-sign` chain used by the Tabby app build, so
+> the proper long-term fix belongs upstream.
+
 # Development setup
 
 Put your environment vars (`DATABASE_URL`, etc.) in the `.env` file in the root of the repo.

--- a/backend/tabby/app/management/commands/add_version.py
+++ b/backend/tabby/app/management/commands/add_version.py
@@ -1,5 +1,6 @@
 import fsspec
 import logging
+import re
 import requests
 import shutil
 import subprocess
@@ -60,7 +61,47 @@ class Command(BaseCommand):
                             Path(extraction_tmp) / "package", plugin_final_target
                         )
 
+            self._patch_web_ssh_signing(tempdir)
+
             if fs.exists(target):
                 fs.rm(target, recursive=True)
             fs.mkdir(target)
             fs.put(str(tempdir), target, recursive=True)
+
+    # Patterns for the in-browser SSH public-key signing fix (see below).
+    _SSH_SIGN_FIXES = [
+        (re.compile(r"""signatureAlgo\s*=\s*['"]sha512['"]"""), "signatureAlgo = 'RSA-SHA512'"),
+        (re.compile(r"""signatureAlgo\s*=\s*['"]sha256['"]"""), "signatureAlgo = 'RSA-SHA256'"),
+    ]
+
+    def _patch_web_ssh_signing(self, root: Path):
+        """Fix in-browser SSH public-key authentication.
+
+        Tabby runs ssh2 in the browser, where Node's `crypto` is polyfilled by
+        `browserify-sign`. For an RSA user key, ssh2 asks that polyfill to sign
+        with the bare digest name ('sha256'/'sha512'), but browserify-sign maps
+        those names to an ECDSA algorithm entry whose PKCS#1 DigestInfo prefix is
+        empty. The result is either a thrown "wrong private key type" error or a
+        signature with no DigestInfo that the server rejects -- so public-key auth
+        fails in the web build while it works on the desktop (native crypto).
+        See Eugeny/tabby#8069 and Eugeny/tabby-connection-gateway#11.
+
+        Rewriting the algorithm to the proper `RSA-SHA512`/`RSA-SHA256` names makes
+        ssh2 use the algorithm entries that carry the correct DigestInfo, producing
+        valid rsa-sha2-* signatures. Done here, every downloaded version is fixed.
+        """
+        patched = 0
+        for js in root.rglob("*.js"):
+            try:
+                text = js.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            if "signatureAlgo" not in text:
+                continue
+            new = text
+            for pattern, replacement in self._SSH_SIGN_FIXES:
+                new = pattern.sub(replacement, new)
+            if new != text:
+                js.write_text(new, encoding="utf-8")
+                patched += 1
+        logging.info(f"Applied in-browser SSH public-key signing fix to {patched} file(s)")


### PR DESCRIPTION
## Problem

SSH **public-key** authentication does not work in the web build. Connecting with a private key fails with:

```
Error signing data with key: wrong private key type
```

so users are forced to fall back to password auth. Reported in #8069 and Eugeny/tabby-connection-gateway#11 (open since early 2023).

## Root cause

Tabby runs `ssh2` in the browser, where Node's `crypto` is polyfilled by `browserify-sign`.

When signing the public-key auth challenge for an **RSA** user key, `ssh2` calls the signer with the bare digest name (`'sha256'` / `'sha512'`). In `browserify-sign`'s `algorithms.json`, those bare names map to:

```json
"sha512": { "sign": "ecdsa", "hash": "sha512", "id": "" }
```

i.e. `sign: "ecdsa"` with an **empty** PKCS#1 `DigestInfo` prefix (`id`). So the RSA branch of `browserify-sign`'s `sign()` either throws `wrong private key type` (signType `ecdsa` ≠ `rsa`/`ecdsa/rsa`), or — once past that — produces an RSA signature with **no DigestInfo**, which the server rejects.

The desktop app is unaffected because it signs via native `crypto`, not the browser polyfill.

## Fix

Request the proper RSA-SHA2 algorithm names (`RSA-SHA512` / `RSA-SHA256`), whose `algorithms.json` entries carry the correct `DigestInfo`:

```json
"RSA-SHA512": { "sign": "ecdsa/rsa", "hash": "sha512", "id": "3051300d06096086480165030402030500..." }
```

This yields valid `rsa-sha2-512` / `rsa-sha2-256` signatures that the server accepts. Since the bug lives in the published, pre-built app bundles, the rewrite is applied in `add_version` after each version is downloaded, so every installed version is fixed automatically. The `ecdsa`/bare-digest path is left untouched.

## Notes

This is a post-build patch of the published bundles from the Django side — the underlying issue is in the `ssh2` / `browserify-sign` chain used by the Tabby app build, so a long-term fix ideally lands there too. Verified end-to-end against OpenSSH 9.6 with an RSA key over a self-hosted connection gateway: signing now produces a valid `rsa-sha2-512` signature and the server returns `Accepted publickey`.

Fixes #8069
